### PR TITLE
improvement(vuehorizontaltimeline): adds Scoped Slot compatibility

### DIFF
--- a/src/components/VueHorizontalTimeline.vue
+++ b/src/components/VueHorizontalTimeline.vue
@@ -4,7 +4,7 @@
       <ol>
         <li v-for="(item, i) in items" :key="i" :style="setLineColor">
           <div class="time" :class="getTimeClass(item)" :style="getTimeStyles" @click="cardClicked(item)">
-            <slot v-if="hasSlot"/>
+            <slot v-if="hasSlot" v-bind:item="item"/>
             <span
               class="title"
               v-if="!hasSlot && item[titleAttr]"


### PR DESCRIPTION
## Scoped Slot Compatibility

Hey! I love this package, but I ran into an issue while trying to access data from each "item" while using a slot for the cards. With this modification, I was able to organize data however I wanted, and then grab that data in my slot from 'slotProps'. You can see what I am talking about [here](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots)

As of vue 2.6.0, the recommended way to scope slots is by passing data up from the child component.
By binding each item of the iteration, we can access specific data about that item in our slot
template.

I used this feature to build a slot with a formatted list, but the possibilities are endless, as users could build reusable components on the cards that adjust dynamically to the data passed in.

```vue
<vue-horizontal-timeline
   :items="items"
   v-bind:has-slot="true"
   v-slot:default="slotProps"
 >
   <div class="timeline-card">
     <h6 class="card-title">
       {{ slotProps.item.title }}
     </h6>
     <img :src="slotProps.item.image">
     <ul>
       <p
         v-for="(question, i) in slotProps.item.content"
         :key="i"
         class="card-list-item"
       >
         {{ question }}
       </p>
     </ul>
   </div>
</vue-horizontal-timeline>
```