### PR TITLE
Solved the scopedSlot issue of latest vue

### DIFF
--- a/src/components/VueHorizontalTimeline.vue
+++ b/src/components/VueHorizontalTimeline.vue
@@ -4,16 +4,16 @@
       <ol>
         <li v-for="(item, i) in items" :key="i" :style="setLineColor">
           <div class="time" :class="getTimeClass(item)" :style="getTimeStyles" @click="cardClicked(item)">
-            <slot v-if="$slots.default" v-bind:item="item"/>
+            <slot v-if="$scopedSlots.default" v-bind:item="item"/>
             <span
               class="title"
-              v-if="!$slots.default && item[titleAttr]"
+              v-if="!$scopedSlots.default && item[titleAttr]"
               :class="getTitleClasses">
               {{ item[titleAttr] | textSubstr(titleSubstr) }}
             </span>
             <span
               class="content"
-              v-if="!$slots.default && item[contentAttr]"
+              v-if="!$scopedSlots.default && item[contentAttr]"
               :class="getContentClasses">
               {{ item[contentAttr] | textSubstr(contentSubstr) }}
             </span>


### PR DESCRIPTION
A bug exists in current vue(v2.6.11): `v-if` evaluated `false` when component utilized by 
`<template v-slot="...">`
 or
 `<template slot-scope="...">`. 
This makes `:item` virtually inaccessible. See the issue here: [vue issue#11084](https://github.com/vuejs/vue/issues/11084).
Here's the simple workaround as proposed from the issue: replace `$slots` with `$scopedSlots`.